### PR TITLE
Removes logged in user link

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -104,3 +104,11 @@
     padding:10px;
   }
 }
+
+// creates styles for text in the navbar that is not a link
+.navbar .nav > li > span
+{
+	padding: 10px 15px 10px;
+	color:#DE9292;
+	display:block;
+}

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -2,7 +2,8 @@
 %ul.nav
   - if user_signed_in?
     %li
-      = link_to "Logged in as #{current_user.name}", ""
+      %span
+        Logged in as #{current_user.name}
     %li
       = link_to 'Sign out', destroy_user_session_path, :method=>'delete'
   - else


### PR DESCRIPTION
Fixes 35 - Logged in user text was a link to the current page. This
commit removes the link so that this text just serves as a status
update.
