### PR TITLE
Removes existing categories

### DIFF
--- a/app/views/hsa/show.html.haml
+++ b/app/views/hsa/show.html.haml
@@ -41,16 +41,7 @@
       = render "forms/service_areas", :service => service
       = render "forms/keywords", :service => service
 
-      %div.content-box
-        %p
-          %strong= "Existing Categories:"
-          %ul#existing-categories
-            - if service.key?(:categories)
-              - cats = service.categories
-              - @slugs = cats.map(&:slugs)
-              - cats.each do |cat|
-                %li
-                  = cat.name
+      - @slugs = service.categories.map(&:slugs) if service.key?(:categories)
       %div#categories.inst-box
         %header
           %strong

--- a/spec/features/update_service_categories_spec.rb
+++ b/spec/features/update_service_categories_spec.rb
@@ -21,9 +21,6 @@ feature "Update a service's categories" do
     click_button "Save changes"
     visit_test_location
     find("#category_emergency").should be_checked
-    within("#existing-categories") do
-      expect(page).to have_content "Disaster Response"
-    end
     find("#category_disaster-response").should be_checked
     reset_categories
     visit_test_location


### PR DESCRIPTION
Removes "existing categories" box, as this is no longer needed due to
the updated functionality of the categories remembering their values.
