### PR TITLE
Adds link back to last edited location

### DIFF
--- a/app/controllers/hsa_controller.rb
+++ b/app/controllers/hsa_controller.rb
@@ -186,7 +186,7 @@ class HsaController < ApplicationController
       }
     )
 
-    redirect_to locations_path, notice: "Changes for #{location_name} successfully saved!" and return
+    redirect_to locations_path, notice: "Changes for <a href='#{location_id}'>#{location_name}</a> successfully saved!".html_safe and return
   end
 
   def create_location


### PR DESCRIPTION
After editing a location the success message provided the name of the
last edited location, but as plain text. This commit turns the name
into a link back to the last edited location.
