### PR TITLE
Add ability to add an admin to a location

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,7 @@ class ApplicationController < ActionController::Base
     {
       :accessibility  => accessibility,
       :address        => address,
+      :admins         => admins,
       :contacts       => contacts,
       :description    => params[:description],
       :emails         => emails,
@@ -54,6 +55,13 @@ class ApplicationController < ActionController::Base
         :state => params[:state],
         :zip => params[:zip]
       }
+    end
+  end
+
+  def admins
+    admins = params[:admins]
+    if admins.present? && !admins.all?(&:empty?)
+      params[:admins].delete_if { |admin| admin.blank? }
     end
   end
 

--- a/app/views/forms/_add_admin.html.haml
+++ b/app/views/forms/_add_admin.html.haml
@@ -1,0 +1,2 @@
+%fieldset#admins
+  = text_field_tag "admins[]", "", class: "span4"

--- a/app/views/forms/_admins.html.haml
+++ b/app/views/forms/_admins.html.haml
@@ -1,0 +1,11 @@
+%div.inst-box
+  - if @location.key?(:admins)
+    - @location.admins.each_with_index do |admin, i|
+      %fieldset#admins
+        = text_field_tag "admins[]", admin, class: "span4", id: "admin_#{i}"
+        %br
+        = link_to "Delete this admin permanently", '#', class: "btn btn-danger"
+  - fields = render "forms/add_admin"
+  %p
+    = link_to_function "Add an admin", ("add_fields(1, this, \"#{escape_javascript(fields)}\")"), class: "btn btn-primary"
+

--- a/app/views/forms/_short_desc.html.haml
+++ b/app/views/forms/_short_desc.html.haml
@@ -5,4 +5,4 @@
     %p.desc
       A short summary of the description of services.
   %p
-    = text_area_tag "short_desc", @location.key?(:short_desc) ? @location.short_desc : "", :class => "span9", maxlength: 200
+    = text_area_tag "short_desc", @location.key?(:short_desc) ? @location.short_desc : "", :class => "span9"

--- a/app/views/forms/new/_short_desc.html.haml
+++ b/app/views/forms/new/_short_desc.html.haml
@@ -5,4 +5,4 @@
     %p.desc
       A short summary of the description of services.
   %p
-    = text_area_tag "short_desc", "", :class => "span9", maxlength: 200
+    = text_area_tag "short_desc", "", :class => "span9"

--- a/app/views/hsa/index.html.haml
+++ b/app/views/hsa/index.html.haml
@@ -4,6 +4,7 @@
 Below you should see a list of locations that you are allowed to administer based on your email address.
 If there are any locations missing, please #{mail_to "sanmateoco@codeforamerica.org", "let us know"}.
 %p
+%p
   To start updating, click on one of the links, which will take you to the details page
   for the location.
 - if current_user.role == "admin"

--- a/app/views/hsa/show.html.haml
+++ b/app/views/hsa/show.html.haml
@@ -8,6 +8,14 @@
   %div.content-box
     %h2= loc_name == org_name ? loc_name : "#{org_name} / #{loc_name}"
 
+  - if current_user.role == "admin" || (@location.key?(:admins) && @location.admins.include?(current_user.email))
+    %div.content-box
+      %h4
+        Add an admin to this location
+      %p
+        Which email addresses should be allowed to update and delete this location?
+      = render "forms/admins"
+
   = render "forms/org_name"
   = render "forms/location_name"
   = render "forms/description"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Hsa::Application.routes.draw do
 
   devise_for :users
 
-  root :to => "home#index"
+  root :to => "hsa#index"
   match "/locations" => "hsa#index"
   match "/locations/new" => "hsa#new"
   match "/locations/create_location" => "hsa#create_location"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,15 +9,15 @@
 # See http://railsapps.github.io/rails-environment-variables.html
 
 puts '===> Setting up first test user...'
-user = User.create! :name => 'Samaritan House',
+user = User.create! :name => 'User with custom domain name',
                     :email => 'ohana@samaritanhouse.com',
                     :password => 'ohanatest',
                     :password_confirmation => 'ohanatest'
 user.confirm!
 
 puts '===> Setting up second test user...'
-user2 = User.create! :name => 'Peninsula Family Service',
-                     :email => 'ohana@peninsulafamilyservice.org',
+user2 = User.create! :name => 'User with generic email',
+                     :email => 'ohana@gmail.com',
                      :password => 'ohanatest',
                      :password_confirmation => 'ohanatest'
 user2.confirm!

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,6 +8,10 @@ FactoryGirl.define do
     password_confirmation 'mong01dtest'
     # required if the Devise Confirmable module is used
     confirmed_at Time.now
+
+    factory :second_user do
+      email "moncef@smcgov.org"
+    end
   end
 
   factory :admin_user, :class => :user do

--- a/spec/features/access_location_spec.rb
+++ b/spec/features/access_location_spec.rb
@@ -1,0 +1,60 @@
+require "spec_helper"
+
+feature "Accessing a specific location" do
+  scenario "when location doesn't include generic email" do
+    user = create(:second_user)
+    login_user(user)
+    visit("/san-mateo-free-medical-clinic")
+    expect(page).to have_content "Sorry, you don't have access to that page"
+  end
+
+  scenario "when location doesn't include domain name" do
+    user = create(:user)
+    login_user(user)
+    visit("/main-library")
+    expect(page).to have_content "Sorry, you don't have access to that page"
+  end
+
+  scenario "when location includes domain name" do
+    user = create(:user)
+    login_user(user)
+    visit("/san-mateo-free-medical-clinic")
+    expect(page).to_not have_content "Sorry, you don't have access to that page"
+  end
+
+  scenario "when user is location admin", js: true do
+    new_admin = create(:second_user)
+    set_user_as_admin(new_admin.email, "San Mateo Free Medical Clinic")
+    login_user(new_admin)
+    visit("/san-mateo-free-medical-clinic")
+    expect(page).to_not have_content "Sorry, you don't have access to that page"
+    delete_all_admins
+  end
+
+  scenario "when user is location admin but has non-generic email", js: true do
+    new_admin = create(:user)
+    set_user_as_admin(new_admin.email, "Little House")
+    login_user(new_admin)
+    visit("/little-house")
+    expect(page).to have_content "Sorry, you don't have access to that page"
+    click_link "Sign out"
+    sign_in(@admin.email, @admin.password)
+    visit("/little-house")
+    delete_all_admins
+  end
+
+  scenario "when user is master admin" do
+    login_admin
+    visit("/little-house")
+    expect(page).to_not have_content "Sorry, you don't have access to that page"
+  end
+
+  context "when user doesn't belong to any locations" do
+    it "denies access to create a new location" do
+      user = create(:second_user)
+      sign_in(user.email, user.password)
+      visit("/locations/new")
+      expect(page).to have_content "Sorry, you don't have access to that page"
+    end
+  end
+end

--- a/spec/features/access_locations_spec.rb
+++ b/spec/features/access_locations_spec.rb
@@ -27,4 +27,25 @@ feature "Accessing /locations" do
       to have_content 'You need to sign in or sign up before continuing.'
   end
 
+  context "when signed in as location admin", js: true do
+    it "should display the add new location button" do
+      new_admin = create(:second_user)
+      set_user_as_admin(new_admin.email, "San Mateo Free Medical Clinic")
+      login_user(new_admin)
+      visit_locations
+      expect(page).to have_link "Add a new location"
+      visit("/san-mateo-free-medical-clinic")
+      delete_all_admins
+    end
+  end
+
+  context "when signed in as user with no locations" do
+    it "should not display the add new location button" do
+      user = create(:second_user)
+      login_user(user)
+      visit_locations
+      expect(page).to_not have_link "Add a new location"
+    end
+  end
+
 end

--- a/spec/features/create_location_spec.rb
+++ b/spec/features/create_location_spec.rb
@@ -2,7 +2,8 @@ require "spec_helper"
 
 feature "Create a new location" do
   background do
-    login_user
+    user = create(:user)
+    login_user(user)
     visit_locations
     click_link "Add a new location"
   end
@@ -16,7 +17,6 @@ feature "Create a new location" do
   scenario "with all required fields", :js => true do
     fill_in "location_name", with: "new samaritan house location"
     fill_in "description", with: "new description"
-    fill_in "short_desc", with: "new short description"
     fill_in "street", with: "1486 Huntington Avenue, Suite 100"
     fill_in "city", with: "Redwood City"
     fill_in "state", with: "XX"
@@ -24,7 +24,6 @@ feature "Create a new location" do
     click_button "Create new location for Samaritan House"
     find_field('location_name').value.should eq "new samaritan house location"
     find_field('description').value.should eq "new description"
-    find_field('short_desc').value.should eq "new short description"
     find_field('street').value.should eq "1486 Huntington Avenue, Suite 100"
     find_field('city').value.should eq "Redwood City"
     find_field('state').value.should eq "XX"
@@ -34,7 +33,6 @@ feature "Create a new location" do
 
   scenario "with empty description" do
     fill_in "location_name", with: "new samaritan house location"
-    fill_in "short_desc", with: "new short description"
     fill_in "street", with: "1486 Huntington Avenue, Suite 100"
     fill_in "city", with: "Redwood City"
     fill_in "state", with: "XX"
@@ -45,7 +43,6 @@ feature "Create a new location" do
 
   scenario "with empty name" do
     fill_in "description", with: "new description"
-    fill_in "short_desc", with: "new short description"
     fill_in "street", with: "modularity"
     fill_in "city", with: "utopia"
     fill_in "state", with: "XX"
@@ -54,21 +51,9 @@ feature "Create a new location" do
     expect(page).to have_content "Location name can't be blank!"
   end
 
-  scenario "with empty short description" do
-    fill_in "location_name", with: "new samaritan house location"
-    fill_in "description", with: "new description"
-    fill_in "street", with: "modularity"
-    fill_in "city", with: "utopia"
-    fill_in "state", with: "XX"
-    fill_in "zip", with: "12345"
-    click_button "Create new location for Samaritan House"
-    expect(page).to have_content "Please enter a short description"
-  end
-
   scenario "with no address" do
     fill_in "location_name", with: "new samaritan house location"
     fill_in "description", with: "new description"
-    fill_in "short_desc", with: "new short description"
     click_button "Create new location for Samaritan House"
     expect(page).to have_content "Please enter at least one type of address"
   end
@@ -291,5 +276,22 @@ feature "Create a new location" do
     find("#category_emergency").should be_checked
     find("#category_disaster-response").should be_checked
     delete_location
+  end
+end
+
+describe "creating a new location as user with generic email" do
+  context "after creating the location", js: true do
+    it "sets the current user as an admin for the new location" do
+      user = create(:second_user)
+      set_user_as_admin(user.email, "Little House")
+      sign_in(user.email, user.password)
+      click_link "Add a new location"
+      fill_in_all_required_fields
+      click_button "Create new location for Peninsula Volunteers"
+      find_field('admins[]').value.should eq user.email
+      delete_location
+      visit("/little-house")
+      delete_all_admins
+    end
   end
 end

--- a/spec/features/location_admin_authorization_spec.rb
+++ b/spec/features/location_admin_authorization_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+describe "ability to add an admin to a location" do
+  context "when neither master admin nor location admin" do
+    it "doesn't allow adding an admin" do
+      user = create(:user)
+      login_user(user)
+      visit_locations
+      click_link "San Mateo Free Medical Clinic"
+      expect(page).to_not have_content ("Add an admin")
+    end
+  end
+
+  context "when master admin" do
+    it "allows adding an admin" do
+      login_admin
+      visit_locations
+      click_link "San Mateo Free Medical Clinic"
+      expect(page).to have_content ("Add an admin")
+    end
+  end
+
+  context "when location admin", js: true do
+    it "allows adding an admin" do
+      new_admin = create(:second_user)
+      set_user_as_admin(new_admin.email, "San Mateo Free Medical Clinic")
+      login_user(new_admin)
+      visit_locations
+      click_link "San Mateo Free Medical Clinic"
+      expect(page).to have_content ("Add an admin")
+      delete_all_admins
+    end
+  end
+end

--- a/spec/features/update_location_admins_spec.rb
+++ b/spec/features/update_location_admins_spec.rb
@@ -1,0 +1,68 @@
+require "spec_helper"
+
+feature "Update a location's admins" do
+  background do
+    login_admin
+  end
+
+  scenario "when location doesn't have any admins" do
+    visit_location_with_no_phone
+    page.should have_no_selector(
+      :xpath, "//input[@type='text' and @name='admins[]']")
+  end
+
+  scenario "by adding 2 new admins", :js => true do
+    visit_location_with_no_phone
+    add_two_admins
+    visit_location_with_no_phone
+    total_admins = page.
+      all(:xpath, "//input[@type='text' and @name='admins[]']")
+    total_admins.length.should eq 2
+    delete_all_admins
+    visit_location_with_no_phone
+    page.should have_no_selector(
+      :xpath, "//input[@type='text' and @name='admins[]']")
+  end
+
+  scenario "with empty admin", :js => true do
+    visit_test_location
+    click_link "Add an admin"
+    page.should have_selector(
+      :xpath, "//input[@type='text' and @name='admins[]']")
+    click_button "Save changes"
+    visit_test_location
+    page.should have_no_selector(
+      :xpath, "//input[@type='text' and @name='admins[]']")
+  end
+
+  scenario "with 2 admins but one is empty", :js => true do
+    visit_test_location
+    click_link "Add an admin"
+    fill_in "admins[]", with: "moncef@samaritanhouse.com"
+    click_link "Add an admin"
+    click_button "Save changes"
+    visit_test_location
+    total_admins = page.
+      all(:xpath, "//input[@type='text' and @name='admins[]']")
+    total_admins.length.should eq 1
+    delete_all_admins
+  end
+
+  scenario "with valid admin", :js => true do
+    visit_test_location
+    click_link "Add an admin"
+    fill_in "admins[]", with: "moncef@samaritanhouse.com"
+    click_button "Save changes"
+    visit_test_location
+    find_field('admins[]').value.should eq "moncef@samaritanhouse.com"
+    delete_all_admins
+  end
+
+  scenario "with invalid admin", :js => true do
+    visit_test_location
+    click_link "Add an admin"
+    fill_in "admins[]", with: "moncefsamaritanhouse.com"
+    click_button "Save changes"
+    expect(page).to have_content "Please enter a valid admin email address"
+  end
+end

--- a/spec/features/update_location_short_description_spec.rb
+++ b/spec/features/update_location_short_description_spec.rb
@@ -5,13 +5,6 @@ feature "Update a location's short description" do
     login_admin
   end
 
-  scenario "with empty short description" do
-    visit_test_location
-    fill_in "short_desc", with: ""
-    click_button "Save changes"
-    expect(page).to have_content "Please enter a short description"
-  end
-
   scenario "with valid description" do
     visit_test_location
     fill_in "short_desc", with: "This is a short description"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
 
 RSpec.configure do |config|
   #config.treat_symbols_as_metadata_keys_with_true_values = true
+  config.include FactoryGirl::Syntax::Methods
   config.include Features::SessionHelpers, type: :feature
   config.include Warden::Test::Helpers
   Warden.test_mode!

--- a/spec/support/features/session_helpers.rb
+++ b/spec/support/features/session_helpers.rb
@@ -15,8 +15,7 @@ module Features
       login_as(admin, :scope => :user)
     end
 
-    def login_user
-      user = FactoryGirl.create(:user)
+    def login_user(user)
       login_as(user, :scope => :user)
     end
 
@@ -142,6 +141,23 @@ module Features
       click_button "Save changes"
     end
 
+    def add_two_admins
+      click_link "Add an admin"
+      fill_in "admins[]", with: "moncef@foo.com"
+      click_link "Add an admin"
+      admins = page.all(:xpath, "//input[@type='text' and @name='admins[]']")
+      fill_in admins[-1][:id], with: "moncef@otherlocation.com"
+      click_button "Save changes"
+    end
+
+    def delete_all_admins
+      delete_links = all("a", :text => "Delete this admin permanently")
+      delete_links.each do |a|
+        click_link a.text, match: :first
+      end
+      click_button "Save changes"
+    end
+
     def add_street_address
       fill_in "street", with: "1486 Huntington Avenue, Suite 100"
       fill_in "city", with: "Redwood City"
@@ -224,6 +240,17 @@ module Features
     def delete_location
       find_link("Permanently delete this location").click
       find_link("I understand the consequences, delete this location").click
+    end
+
+    def set_user_as_admin(email, location)
+      @admin = create(:admin_user)
+      sign_in(@admin.email, @admin.password)
+      visit_locations
+      click_link location
+      click_link "Add an admin"
+      fill_in "admins[]", with: email
+      click_button "Save changes"
+      click_link "Sign out"
     end
   end
 end


### PR DESCRIPTION
This commit also includes other fixes and enhancements such as:
- remove the short_description requirement
- remove the maxlength constraint for short_description
- refactor authorization methods
- redirect to "/locations" with error message if new location can't be created
- fix "new" action so that it checks for presence of locations and org
- send user directly to "/locations" after signing in
- update seeds and factories to include a user with a generic email
- when a user with a generic email creates a new location, automatically make them an admin for that location
